### PR TITLE
Fix empty homepage leaderboard: replace row-value tuple IN with OR/AND pairs

### DIFF
--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -28,6 +28,7 @@ import {
   eq,
   DrizzleError,
   and,
+  or,
   asc,
   desc,
   isNotNull,
@@ -38,6 +39,8 @@ import { SQLiteTransaction } from "drizzle-orm/sqlite-core";
 import { ResultSet } from "@libsql/client";
 
 export const getModelVariants = async (filters: UniqueModel[]) => {
+  if (filters.length === 0) return [];
+
   const result = await db
     .select({
       variantId: modelVariants.id,
@@ -48,9 +51,13 @@ export const getModelVariants = async (filters: UniqueModel[]) => {
     .from(modelVariants)
     .innerJoin(models, eq(modelVariants.model_id, models.id))
     .where(
-      inArray(
-        sql`(${models.name}, ${modelVariants.quantization})`,
-        filters.map((spec) => [spec.name, spec.quant])
+      or(
+        ...filters.map((spec) =>
+          and(
+            eq(models.name, spec.name),
+            eq(modelVariants.quantization, spec.quant)
+          )
+        )
       )
     );
 
@@ -58,13 +65,19 @@ export const getModelVariants = async (filters: UniqueModel[]) => {
 };
 
 export const getAccelerators = async (filters: UniqueAccelerator[]) => {
+  if (filters.length === 0) return [];
+
   const result = await db
     .select({ id: accelerators.id })
     .from(accelerators)
     .where(
-      inArray(
-        sql`(${accelerators.name}, ${accelerators.memory_gb})`,
-        filters.map((spec) => [spec.name, spec.memory])
+      or(
+        ...filters.map((spec) =>
+          and(
+            eq(accelerators.name, spec.name),
+            eq(accelerators.memory_gb, spec.memory)
+          )
+        )
       )
     );
 


### PR DESCRIPTION
## Symptom

The homepage leaderboard on localscore.ai renders its tab chrome but zero rows. The page's own data payload is empty:

```
GET https://www.localscore.ai/_next/data/build-TfctsWXpff2fKS/index.json
→ {"pageProps":{"results":[]},"__N_SSG":true}
```

Everything else on the site is healthy — `/latest` shows results through today, `/api/search` returns live models and accelerators, `/accelerator/4016` works, and `/model/3` (Llama 3.2 1B Q4_K-M) renders a full 826-accelerator leaderboard. The database, the perf-score table and the official model variants are all fine.

`/` is the only `getStaticProps` page in the app; every other data page is `getServerSideProps`. That's why this one page is dark and nothing else is.

## Not a stale cache, and not a bad deploy

- Polling the data route shows ISR actually cycling (`age` climbs to ~60, goes `STALE`, resets to ~19 as a fresh entry is written). It regenerates every 60s and regenerates *to empty*.
- The Wayback snapshot from **2026-07-22 has `results` with 3 model groups** (20/13/12 accelerators). The 2026-08-05 snapshot has `results: []`. **Both carry the same `buildId` `build-TfctsWXpff2fKS` as the site right now** — same deployment, same code, same lockfile. Nothing shipped; it broke underneath a running deployment.

## Root cause

The chain in `getStaticProps` is `getModelVariants` → `getTopAcceleratorsByModelVariants` → `getPerformanceScores`.

`getPerformanceScores` builds its output by mapping over `modelInfo`, so if it got even one variant id back you'd see 3 groups with empty inner `results` arrays. A **length-0 outer array can only happen if `getModelVariants` returned zero rows.**

`getModelVariants` is the only query in the codebase using SQLite **row-value tuple `IN`**:

```sql
where ("models"."name", "model_variants"."quantization") in ((?,?), (?,?), (?,?))
```

The rows it looks for are definitely present. `/api/search` returns `Llama 3.2 1B Instruct` / `Q4_K - Medium` (variant 3), `Meta Llama 3.1 8B Instruct` / `Q4_K - Medium` (variant 1) and `Qwen2.5 14B Instruct` / `Q4_K - Medium` (variant 2), matching `OFFICIAL_MODELS` character for character.

I reproduced the exact generated SQL locally against libsql/SQLite 3.45 — small, and at ~3,900-row scale with the same unique indexes — and it returns all 3 rows correctly. Combined with the unchanged `buildId`, that puts the failure on the production database engine rather than in this repo. I can't verify from outside the account, but a Turso engine migration where row-value `IN (VALUES…)` isn't handled the same way would fit both the behaviour and the timing.

## Why it failed silently instead of erroring

Once `getModelVariants` returns `[]`, nothing downstream complains. Drizzle compiles `inArray(col, [])` to `where false` rather than throwing, so `getTopAcceleratorsByModelVariants` returns `[]`, `getPerformanceScores` maps over an empty `modelInfo`, and `getStaticProps` returns a perfectly valid page with no data. No exception, no error page, no stale-cache signal — which is how this stayed up for ~3 weeks.

## The fix

Drop to `OR`-of-`AND` pairs. Portable, no dependency on row-value support, and it hits the same indexes — `EXPLAIN QUERY PLAN` gives `SEARCH models USING COVERING INDEX model_name_idx` and `SEARCH model_variants USING COVERING INDEX model_variant_unique_idx` either way.

`getAccelerators` has the identical tuple-IN shape and would fail the same way, so it gets the same treatment. Both grow an explicit empty-filters guard, because `or()` with no arguments returns `undefined` and `.where(undefined)` would select every row.

## Verification

Ran the full `getStaticProps` chain against the committed `db.sqlite`, before and after the patch:

```
### BEFORE (original tuple-IN) ###
results groups: 3
  Meta Llama 3.1 8B Instruct / Q4_K - Medium -> 4 accelerators
  Qwen2.5 14B Instruct / Q4_K - Medium      -> 2 accelerators
  Llama 3.2 1B Instruct / Q4_K - Medium     -> 7 accelerators

### AFTER (patched) ###
results groups: 3
  Meta Llama 3.1 8B Instruct / Q4_K - Medium -> 4 accelerators
  Qwen2.5 14B Instruct / Q4_K - Medium      -> 2 accelerators
  Llama 3.2 1B Instruct / Q4_K - Medium     -> 7 accelerators
```

Identical — the rewrite is behaviour-preserving on an engine where the tuple form works. `npx tsc --noEmit` is clean, `npm run build` succeeds, and the prerendered `.next/server/pages/index.json` comes out populated rather than `{"results":[]}`.

## Suggested follow-ups (not in this PR)

- Have `getStaticProps` throw (or skip `revalidate`) when `modelVariants.length === 0`, so a query that stops matching surfaces as an error instead of silently publishing an empty leaderboard.
- Worth running that tuple query directly against the production Turso DB to confirm the engine hypothesis before closing this out — if it *does* return the 3 rows there, the cause is something else and I'd like to keep digging.
